### PR TITLE
Brute-force way to remove identical features

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,6 +12,7 @@
   import Layout from "./Layout.svelte";
   import DatasetLayers from "./DatasetLayers.svelte";
   import LayerControl from "./LayerControl.svelte";
+  import { removeIdenticalFeatures } from "./diff";
 
   // Vivid from https://carto.com/carto-colors/
   let colors = [
@@ -142,6 +143,14 @@
       padding: 10,
     });
   }
+
+  function removeUnchanged() {
+    let len = gjA.features.length;
+    removeIdenticalFeatures(gjA, gjB);
+    gjA = gjA;
+    gjB = gjB;
+    window.alert(`Removed ${len - gjA.features.length} unchanged features`);
+  }
 </script>
 
 <Layout>
@@ -155,6 +164,10 @@
 
     <div><button on:click={zoomFit}>Zoom to fit</button></div>
     <hr />
+
+    <div>
+      <button on:click={removeUnchanged}>Remove unchanged features</button>
+    </div>
 
     {#if filenameA}
       <LayerControl

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,0 +1,33 @@
+import type { Feature, FeatureCollection } from "geojson";
+
+// Modifies the list of features in-place.
+// TODO Replace with a Rust version. This is slow, brute-force, and just temporary
+export function removeIdenticalFeatures(
+  gjA: FeatureCollection,
+  gjB: FeatureCollection,
+) {
+  let setA = new Set(gjA.features.map(toKey));
+  let setB = new Set(gjB.features.map(toKey));
+
+  // TODO Set intersection isn't in Firefox yet
+  let duplicates = new Set();
+  for (let x of setA) {
+    console.log(x);
+    if (setB.has(x)) {
+      duplicates.add(x);
+    }
+  }
+
+  gjA.features = gjA.features.filter((f) => !duplicates.has(toKey(f)));
+  gjB.features = gjB.features.filter((f) => !duplicates.has(toKey(f)));
+}
+
+// JS doesn't have great options for deep object equality
+function toKey(f: Feature): string {
+  let copy = JSON.parse(JSON.stringify(f));
+  // This will always differ
+  delete copy.dataset;
+  // Order of features doesn't matter
+  delete copy.id;
+  return JSON.stringify(copy);
+}

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -12,7 +12,6 @@ export function removeIdenticalFeatures(
   // TODO Set intersection isn't in Firefox yet
   let duplicates = new Set();
   for (let x of setA) {
-    console.log(x);
     if (setB.has(x)) {
       duplicates.add(x);
     }


### PR DESCRIPTION
@sgreenbury, @ciupava, @andrewphilipsmith -- if you're interested in following development, I can tag you in PRs. I've got some immediate cases where slight improvements here would speed up some other work, so I'm going to make a few changes.

This one just adds a brute-force and super simple way to remove features that have entirely the same properties and geometry. A real test case before has too many things to look at:
![Screenshot from 2024-04-19 12-10-13](https://github.com/dabreegster/geodiffr/assets/1664407/1a54eafa-5fdb-4791-bcdc-a101cfc18e5c)
But just the different features are much easier to understand:
![image](https://github.com/dabreegster/geodiffr/assets/1664407/8d9ef447-bdc7-4809-9451-2c6499639e6a)